### PR TITLE
improve type inference, add cute little spinner 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@types/react-jsonschema-form": "^1.6.4",
     "bootstrap": "^3.0.0",
     "json-schema": "^0.2.5",
-    "lodash": "^4.17.15",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-jsonschema-form": "^1.8.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,12 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import React from 'react';
 import Form, { UiSchema } from 'react-jsonschema-form';
 import { JSONSchema6 } from "json-schema";
-import getFromPath from 'lodash/get';
+import Spinner from './Spinner';
 
 import './App.css';
 
+
 interface State {
-    configFetched: boolean,
     config?: {
         uiSchema: UiSchema,
         dataSchema: JSONSchema6,
@@ -17,7 +17,7 @@ interface State {
 
 class App extends React.Component {
     state: State = {
-        configFetched: false,
+        config: undefined,
     }
 
     constructor(props = {}) {
@@ -41,24 +41,28 @@ class App extends React.Component {
     }
 
     render() {
-        const dataSchema = getFromPath(this.state, 'config.dataSchema');
-        const uiSchema = getFromPath(this.state, 'config.uiSchema');
-
+        let pageContent : JSX.Element;
+        if (this.state.config) {
+            pageContent = (
+                <Form
+                    schema={this.state.config.dataSchema}
+                    uiSchema={this.state.config.uiSchema}
+                    onChange={() => console.log('changed')}
+                    onSubmit={() => console.log('submitted')}
+                    onError={() => console.log('errors')}
+                />
+            );
+        } else {
+            pageContent = (
+                <div className="app container-fluid">
+                    <Spinner />
+                </div>
+            );
+        }
         return (
             <div className="App container-fluid">
                 <section>
-                    {
-                        Boolean(dataSchema) && (
-                            <Form
-                                schema={dataSchema}
-                                uiSchema={uiSchema}
-                                onChange={() => console.log('changed')}
-                                onSubmit={() => console.log('submitted')}
-                                onError={() => console.log('errors')}
-                            />
-                        )
-
-                    }
+                    {pageContent}
                 </section>
             </div>
         );

--- a/src/Spinner.css
+++ b/src/Spinner.css
@@ -1,0 +1,21 @@
+.spinner {
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+}
+
+.spinner svg {
+  height: 50px;
+  animation: spin 1000ms infinite linear;
+}
+
+@keyframes spin {
+  from {
+      transform:rotate(0deg);
+  }
+  to {
+      transform:rotate(360deg);
+  }
+}

--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import './Spinner.css';
+
+const Spinner = ({text = 'Loading'}) => (
+  <div className="spinner">
+    <svg viewBox="-10 -10 70 70">
+      <mask id="myMask">
+        <rect x="0" y="0" width="50" height="50" fill="white" />
+        <path d="M25,25 L0,-25 L0,25 Z" fill="black" />
+      </mask>
+      <circle cx="25" cy="25" r="20" mask="url(#myMask)" stroke="green" fill="none" stroke-width="5" />
+    </svg>
+    {text}
+  </div>
+);
+
+export default Spinner;


### PR DESCRIPTION
small improvement to type inference + spinner addition

just wrote a tiny spinner inline because i didn't see one in bootstrap v3. should be easily swappable as necessary. Also removes lodash. nothing against lodash here, we've just got better type inference w/o it in this case and it was the only reference to lodash.

:tada: :tada: :tada:

<img width="733" alt="Screen Shot 2019-09-18 at 6 12 44 PM" src="https://user-images.githubusercontent.com/1979887/65204654-d9019600-da41-11e9-9f94-a51311ec5be7.png">
