### PR TITLE
Add more validation constraints

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -285,6 +285,7 @@
         },
         "title": "Lark Camp Registration",
         "type": "object",
+        "required": ["payer_first_name", "payer_last_name", "payer_email", "payer_phone"],
         "properties": {
             "payer_first_name": {
                 "type": "string",

--- a/public/config.json
+++ b/public/config.json
@@ -285,7 +285,7 @@
         },
         "title": "Lark Camp Registration",
         "type": "object",
-        "required": ["payer_first_name", "payer_last_name", "payer_email", "payer_phone"],
+        "required": ["payer_email"],
         "properties": {
             "payer_first_name": {
                 "type": "string",

--- a/public/config.json
+++ b/public/config.json
@@ -13,7 +13,10 @@
             "ui:help": "VERY IMPORTANT FOR ALL COMMUNICATIONS - If none must put NONE@NONE.COM"
         },
         "payer_number": {
-            "ui:help": "If none put NONE"
+            "ui:help": "If none put NONE",
+            "ui:options": {
+                "inputType": "tel"
+            }
         },
         "payment_type": {
             "ui:description": { "__html": "<p>Full Price - payment by credit card or Paypal</p><p>Discount Price - payment by personal check, bank check, or money order</p><p>All further payments must be made by the same method.<p>" }
@@ -85,15 +88,21 @@
                 "minimum": 0,
                 "default": 0
             },
+            "shirt_count": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9,
+                "default": 0
+            },
             "sizes": {
                 "type": "object",
                 "title": "Sizes",
                 "properties": {
-                    "small": { "$ref": "#/definitions/natural" },
-                    "medium": { "$ref": "#/definitions/natural" },
-                    "large": { "$ref": "#/definitions/natural" },
-                    "xl": { "$ref": "#/definitions/natural" },
-                    "xxl": { "$ref": "#/definitions/natural" }
+                    "small": { "$ref": "#/definitions/shirt_count" },
+                    "medium": { "$ref": "#/definitions/shirt_count" },
+                    "large": { "$ref": "#/definitions/shirt_count" },
+                    "xl": { "$ref": "#/definitions/shirt_count" },
+                    "xxl": { "$ref": "#/definitions/shirt_count" }
                 }
             },
             "address": {
@@ -102,18 +111,23 @@
                 "properties": {
                     "street_address": {
                         "type": "string",
+                        "maxLength": 50,
                         "title": "Address"
                     },
                     "city": {
                         "type": "string",
+                        "maxLength": 50,
                         "title": "City"
                     },
                     "state_or_province": {
                         "type": "string",
+                        "maxLength": 50,
                         "title": "State or Province"
                     },
                     "zip_code":     {
                         "type": "string",
+                        "minLength": 3,
+                        "maxLength": 10,
                         "title": "Zipcode or Postal Code"
                     },
                     "country": {
@@ -123,7 +137,7 @@
                         "default": "United States"
                     }
                 },
-                "required": ["street_address", "country", "city", "state_or_province", "zip_code", "country"]
+                "required": ["street_address", "city", "state_or_province", "zip_code", "country"]
             },
             "accomodations": {
                 "type": "object",
@@ -153,6 +167,7 @@
                                         "title": "Who would you like to be in a cabin with? (if in a cabin)",
                                         "items": {
                                             "type": "string",
+                                            "maxLength": 50,
                                             "title": "Camper Name"
                                         }
                                     }
@@ -168,6 +183,7 @@
                                         "title": "Who will be in your tent/vehicle with you?",
                                         "items": {
                                             "type": "string",
+                                            "maxLength": 50,
                                             "title": "Name"
                                         }
                                     },
@@ -205,6 +221,7 @@
                                         "title": "Who will be in your tent/vehicle with you? (if in a vehicle or tent)",
                                         "items": {
                                             "type": "string",
+                                            "maxLength": 50,
                                             "title": "Name"
                                         }
                                     }
@@ -269,17 +286,28 @@
         "title": "Lark Camp Registration",
         "type": "object",
         "properties": {
-            "payer_first_name": { "type": "string", "title": "Payer First Name" },
-            "payer_last_name": { "type": "string", "title": "Payer Last Name" },
+            "payer_first_name": {
+                "type": "string",
+                "maxLength": 50,
+                "title": "Payer First Name"
+            },
+            "payer_last_name": {
+                "type": "string",
+                "maxLength": 50,
+                "title": "Payer Last Name"
+            },
             "payer_billing_address": { 
                 "$ref": "#/definitions/address"
             },
             "payer_email": {
                 "type": "string",
+                "format": "email",
                 "title": "Email"
             },
             "payer_number": {
                 "type": "string",
+                "maxLength": 20,
+                "pattern": "^((.*?[0-9].*?){10,}|NONE)$",
                 "title": "Phone Number"
             },
             "payment_type": {
@@ -295,16 +323,19 @@
                 "title": "Campers",
                 "type": "array",
                 "minItems": 1,
+                "maxItems": 8,
                 "items": {
                     "type": "object",
                     "required": ["first_name", "last_name"],
                     "properties": {
                         "first_name": {
                             "type": "string",
+                            "maxLength": 50,
                             "title": "First name"
                         },
                         "last_name": {
                             "type": "string",
+                            "maxLength": 50,
                             "title": "Last name"
                         },
                         "gender": {
@@ -314,6 +345,8 @@
                         },
                         "age": {
                             "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
                             "title": "Age, if under 18"
                         },
                         "camper_address": { 
@@ -340,12 +373,15 @@
             "parking_passes": {
                 "type": "array",
                 "title": "Parking Passes",
+                "minItems": 0,
+                "maxItems": 4,
                 "items": {
                     "type": "object",
                     "title": "Parking Pass",
                     "properties": {
                         "holder": {
                             "type": "string",
+                            "maxLength": 50,
                             "title": "Whose name will the parking pass be in?"
                         }
                     }
@@ -361,18 +397,22 @@
             },
             "lta_donation": {
                 "type": "integer",
+                "minimum": 0,
                 "title": "Donation to Lark Traditional Arts (Tax Deductible, Dollars)"
             },
             "woodlands_donation": {
                 "type": "integer",
+                "minimum": 0,
                 "title": "Donation to the Mendicino Woodlands (Tax Deductible, Dollars)"
             },
             "how_did_you_hear": {
                 "type": "string",
+                "maxLength": 50,
                 "title": "How did you hear about Lark Camp?"
             },
             "comments": {
                 "type": "string",
+                "maxLength": 500,
                 "title": "Comments"
             }
         }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -76,6 +76,17 @@ class App extends React.Component {
         return cost;
     }
 
+    transformErrors = (errors: Array<any>) => errors.map(error => {
+        if (error.name === 'pattern' && error.property === '.payer_number') {
+            return {
+                ...error,
+                message: 'Please enter a valid phone number',
+            };
+        }
+
+        return error;
+    });
+
     render() {
         let pageContent : JSX.Element;
         switch(this.state.status){
@@ -92,6 +103,8 @@ class App extends React.Component {
                             onSubmit={this.onSubmit}
                             onError={() => console.log('errors')}
                             formData={this.state.formData}
+                            transformErrors={this.transformErrors}
+                            // liveValidate={true}
                         />
                         <PriceTicker price={this.getPrice()} />
                     </section>


### PR DESCRIPTION
Adds some more validation constraints to various fields. Tested using php-tests/generate-random-reg.js as well as typing into the form with the liveValidate option enabled.

Phone number validation is pretty loose given how complex it would be to get international numbers right. It just has to have 10 digits somewhere in there.

There may be some more fields that should be required; I just added one to get tests passing, and removed one duplicate.